### PR TITLE
fix: Update CSP policy to fix Shiki not working in production

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
 	"app": {
 		"macOSPrivateApi": true,
 		"security": {
-			"csp": "default-src 'self' ipc: http://ipc.localhost; media-src 'self' asset: http://asset.localhost; img-src 'self' asset: http://asset.localhost",
+			"csp": "default-src 'self' ipc: http://ipc.localhost; media-src 'self' asset: http://asset.localhost; img-src 'self' asset: http://asset.localhost; style-src 'self' 'unsafe-inline'",
 			"assetProtocol": {
 				"enable": true,
 				"scope": ["**"]


### PR DESCRIPTION
Shiki works by injecting inline CSS styles directly into <span> tags (e.g., \<span style="color: #abb2bf">). In production environments, Tauri enforces a hardened CSP that treats these as potential security risks.

While 'unsafe-inline' for scripts should be avoided, it is an acceptable workaround for CSS-in-JS and syntax highlighting libraries in desktop environments where the content source is trusted (our own log parser).