### PR TITLE
fix: restore Rust 1.95 Clippy gate

### DIFF
--- a/frame-app/src/app/chrome.rs
+++ b/frame-app/src/app/chrome.rs
@@ -964,8 +964,10 @@ fn update_action_row(
                 })),
             ),
         ),
-        UpdateStatus::UpToDate | UpdateStatus::Disabled(_) | UpdateStatus::Error(_) => None,
-        UpdateStatus::Idle
+        UpdateStatus::UpToDate
+        | UpdateStatus::Disabled(_)
+        | UpdateStatus::Error(_)
+        | UpdateStatus::Idle
         | UpdateStatus::Checking
         | UpdateStatus::Downloading { .. }
         | UpdateStatus::Installing => None,

--- a/frame-app/src/app/update_actions.rs
+++ b/frame-app/src/app/update_actions.rs
@@ -235,7 +235,7 @@ impl FrameRoot {
         .detach();
     }
 
-    pub(super) fn toggle_auto_update_check(&mut self, cx: &mut Context<Self>) -> bool {
+    pub(super) fn toggle_auto_update_check(&mut self, cx: &Context<Self>) -> bool {
         self.auto_update_check = !self.auto_update_check;
         if let Err(error) = self.persist_app_settings() {
             self.update_ui.status = UpdateStatus::Error(error.to_string());
@@ -245,7 +245,7 @@ impl FrameRoot {
         true
     }
 
-    pub(super) fn skip_available_update(&mut self, cx: &mut Context<Self>) -> bool {
+    pub(super) fn skip_available_update(&mut self, cx: &Context<Self>) -> bool {
         let UpdateStatus::Available(info) = &self.update_ui.status else {
             return false;
         };
@@ -269,7 +269,7 @@ impl FrameRoot {
         }
     }
 
-    fn schedule_settings_update_status_dismiss(&mut self, cx: &mut Context<Self>) {
+    fn schedule_settings_update_status_dismiss(&mut self, cx: &Context<Self>) {
         self.update_ui.status_dismiss_epoch = self.update_ui.status_dismiss_epoch.wrapping_add(1);
         let dismiss_epoch = self.update_ui.status_dismiss_epoch;
 

--- a/frame-app/src/runtime_environment.rs
+++ b/frame-app/src/runtime_environment.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 const FLATPAK_INFO_PATH: &str = "/.flatpak-info";
 
 #[must_use]
-pub(crate) fn is_flatpak() -> bool {
+pub fn is_flatpak() -> bool {
     is_flatpak_from(
         std::env::var_os("FLATPAK_ID").is_some(),
         Path::new(FLATPAK_INFO_PATH).is_file(),

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -2202,6 +2202,10 @@ jobs:
     .replace("  __NIXPKGS_JOBS__\n", &nixpkgs_release_jobs(Some("publish_release")))
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "The generated GitHub Actions jobs are kept as one raw template for easier diffing against YAML output."
+)]
 fn nixpkgs_release_jobs(prepare_needs: Option<&str>) -> String {
     let prepare_needs = prepare_needs
         .map(|needs| format!("    needs: {needs}\n"))
@@ -2527,7 +2531,7 @@ fn nixpkgs_release_jobs(prepare_needs: Option<&str>) -> String {
 }
 
 fn publish_nixpkgs_workflow() -> String {
-    let mut workflow = r#"# Generated from xtask::workflows::publish_nixpkgs
+    let mut workflow = r"# Generated from xtask::workflows::publish_nixpkgs
 # Rebuild with `cargo xtask workflows`.
 name: publish nixpkgs
 env:
@@ -2542,7 +2546,7 @@ on:
 permissions:
   contents: read
 jobs:
-"#
+"
     .to_string();
     workflow.push_str(&nixpkgs_release_jobs(None));
     workflow


### PR DESCRIPTION
This is a small, behavior-preserving cleanup to make the documented contributor checks green again.

`cargo xtask ci` now completes with the repository's pinned Rust 1.95.0 toolchain.

Closes #70.

### What changed

- merged update-status match arms with identical behavior
- removed unnecessary mutable `Context` references through the affected update-action call chain
- aligned the Flatpak helper visibility with its containing module
- documented why the generated Nix workflow jobs remain one long raw template
- removed unnecessary raw-string hashes from the publish-nixpkgs workflow template

No application behavior or generated workflow output changes.

### Verification

- `cargo xtask ci`
- `cargo xtask workflows`
- `cargo clippy --manifest-path frame-app/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo clippy --manifest-path tooling/xtask/Cargo.toml --all-targets --locked -- -D warnings`
- `git diff --check`

### Actual screenshots

Before: `affa1fb`, Rust 1.95.0 on macOS. The first run reports five diagnostics:

<img width="1331" height="768" alt="Before fix: terminal showing the first five Rust 1.95 Clippy errors" src="https://github.com/user-attachments/assets/f9210205-7da5-42f7-bd1f-ebe5549abb91" />

Correcting the first layer reveals two more diagnostics in the same call chain:

<img width="1331" height="768" alt="Before fix: terminal showing two downstream Rust 1.95 Clippy errors" src="https://github.com/user-attachments/assets/e25520fa-cd2f-4d69-947b-d22e7b2393ae" />

After: `549629d`, the same Rust and macOS environment. Both touched-crate Clippy commands exit successfully:

<img width="1331" height="768" alt="After fix: terminal showing successful frame-app and tooling xtask Clippy checks" src="https://github.com/user-attachments/assets/c10426ac-a6ea-4c81-8377-f2a3332a8550" />
