### PR TITLE
ci: check frame-updater in xtask

### DIFF
--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -1275,6 +1275,15 @@ fn ci() -> Result<()> {
         &[
             "fmt",
             "--manifest-path",
+            "frame-updater/Cargo.toml",
+            "--check",
+        ],
+    )?;
+    run_command(
+        "cargo",
+        &[
+            "fmt",
+            "--manifest-path",
             "tooling/xtask/Cargo.toml",
             "--check",
         ],
@@ -1286,6 +1295,10 @@ fn ci() -> Result<()> {
     run_command(
         "cargo",
         &["test", "--manifest-path", "frame-app/Cargo.toml"],
+    )?;
+    run_command(
+        "cargo",
+        &["test", "--manifest-path", "frame-updater/Cargo.toml"],
     )?;
     run_command(
         "cargo",
@@ -1310,6 +1323,19 @@ fn ci() -> Result<()> {
             "clippy",
             "--manifest-path",
             "frame-app/Cargo.toml",
+            "--all-targets",
+            "--locked",
+            "--",
+            "-D",
+            "warnings",
+        ],
+    )?;
+    run_command(
+        "cargo",
+        &[
+            "clippy",
+            "--manifest-path",
+            "frame-updater/Cargo.toml",
             "--all-targets",
             "--locked",
             "--",


### PR DESCRIPTION
This keeps the updater under the same local checks as the rest of the Rust workspace.

`cargo xtask ci` now formats, tests, and lints `frame-updater` explicitly.

Closes #72.

### What changed

- added `frame-updater` formatting to the xtask CI sequence
- added the updater's 9 unit tests to the sequence
- added updater Clippy with `--all-targets --locked -- -D warnings`

The change is limited to the existing `ci()` command orchestration in `tooling/xtask/src/main.rs`.

### Verification

- `cargo fmt --manifest-path frame-updater/Cargo.toml --check`
- `cargo test --manifest-path frame-updater/Cargo.toml` — 9 passed
- `cargo clippy --manifest-path frame-updater/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path tooling/xtask/Cargo.toml` — 28 passed
- `cargo xtask ci` on this independent branch — updater formatting and tests run before the existing base-branch Clippy failure tracked in #70
- `cargo xtask ci` on `63c5d2a` plus the gate-restoring commit from #71 (`549629d`) — passed completely in a temporary validation worktree
- `git diff --check`

### Actual screenshots

Before: `affa1fb`. `frame-updater/Cargo.toml` appears zero times in the three manifest-check groups:

<img width="1331" height="768" alt="Before change: terminal showing zero frame-updater checks in cargo xtask ci" src="https://github.com/user-attachments/assets/0df2c8b8-e0f0-4639-b6ac-ab89a818ec9a" />

After: `63c5d2a`. Every manifest appears once for formatting, testing, and Clippy:

<img width="1331" height="768" alt="After change: terminal showing three frame-updater checks in cargo xtask ci" src="https://github.com/user-attachments/assets/96f9eafd-6aca-41c0-b148-c13e433c8562" />
