### PR TITLE
docs: add macOS Metal Toolchain setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,22 @@ Install Xcode Command Line Tools:
 xcode-select --install
 ```
 
+Frame's GPUI shader build also requires the Metal compiler from a full Xcode
+installation. Ensure Xcode is the active developer directory, then verify the
+compiler is available:
+
+```bash
+xcrun metal --version
+```
+
+If that command reports a missing Metal Toolchain, download the component and
+verify it again:
+
+```bash
+xcodebuild -downloadComponent MetalToolchain
+xcrun metal --version
+```
+
 No additional Homebrew packages are required for normal local development.
 `cargo xtask setup-ffmpeg` downloads the FFmpeg and FFprobe binaries used by the
 app during development.


### PR DESCRIPTION
This adds the missing macOS shader-toolchain step where contributors will see it during setup.

The guide now explains how to verify and install Xcode's Metal Toolchain before building Frame.

Closes #75.

### What changed

- documented that the GPUI shader build needs the Metal compiler from a full Xcode installation
- added `xcrun metal --version` as a quick prerequisite check
- added `xcodebuild -downloadComponent MetalToolchain` for the missing-component case

The change is limited to the macOS section of `CONTRIBUTING.md`.

### Verification

- `xcrun metal --version`
- `cargo test --manifest-path frame-app/Cargo.toml --no-run`
- `cargo xtask ci` on `95958da` plus the gate-restoring commit from #71 (`549629d`) — passed completely in a temporary validation worktree
- `git diff --check`

### Actual screenshots

Before: `affa1fb`, Xcode 26.6 on macOS. The guide has no Metal Toolchain step, and the documented Command Line Tools environment cannot resolve `metal`:

<img width="1331" height="768" alt="Before documentation change: terminal showing no MetalToolchain instruction and a failed Command Line Tools metal lookup" src="https://github.com/user-attachments/assets/96bf9e30-4df6-4e3f-b574-babbff6f54ea" />

After: `95958da`, on the same Mac. The download command is documented, the installed compiler responds, and the app test build exits successfully:

<img width="1331" height="768" alt="After documentation change: terminal showing the MetalToolchain instruction, compiler version, and successful app test build" src="https://github.com/user-attachments/assets/14e78bb2-835e-48c9-a9ad-d9cf6e976f6e" />
