### PR TITLE
Fix conversion notification pluralization

### DIFF
--- a/frame-app/src/notifications.rs
+++ b/frame-app/src/notifications.rs
@@ -60,9 +60,12 @@ impl ConversionNotificationSummary {
 
     #[must_use]
     pub fn body(self) -> String {
+        let file_suffix = if self.completed_count == 1 { "" } else { "s" };
+        let error_suffix = if self.error_count == 1 { "" } else { "s" };
+
         format!(
-            "Processed {} files with {} errors.",
-            self.completed_count, self.error_count
+            "Processed {} file{file_suffix} with {} error{error_suffix}.",
+            self.completed_count, self.error_count,
         )
     }
 }
@@ -368,14 +371,25 @@ mod tests {
     }
 
     #[test]
-    fn conversion_notification_summary_uses_legacy_copy() {
-        let summary = ConversionNotificationSummary {
-            completed_count: 2,
-            error_count: 1,
-        };
+    fn conversion_notification_summary_pluralizes_file_and_error_counts() {
+        let cases = [
+            (2, 1, "Processed 2 files with 1 error."),
+            (1, 2, "Processed 1 file with 2 errors."),
+            (1, 1, "Processed 1 file with 1 error."),
+            (2, 2, "Processed 2 files with 2 errors."),
+            (1, 0, "Processed 1 file with 0 errors."),
+            (0, 1, "Processed 0 files with 1 error."),
+        ];
 
-        assert_eq!(summary.title(), "Queue Finished");
-        assert_eq!(summary.body(), "Processed 2 files with 1 errors.");
+        for (completed_count, error_count, expected) in cases {
+            let summary = ConversionNotificationSummary {
+                completed_count,
+                error_count,
+            };
+
+            assert_eq!(summary.title(), "Queue Finished");
+            assert_eq!(summary.body(), expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Conversion-finished notifications now use grammatically correct singular and plural nouns.

- Pluralizes `file` and `error` independently.
- Covers singular, plural, and zero counts in the existing unit test.
- Keeps the change scoped to notification copy and its regression coverage.

Closes #77.

### Actual screenshots

Before — upstream revision `affa1fb`, exercised against the corrected expectation:

![The notification test fails because the result says 1 errors](https://github.com/user-attachments/assets/dda92b35-05a3-45c1-94f5-eaaa555d984f)

After — revision `c00cf86`:

![The notification pluralization test passes with the corrected copy](https://github.com/user-attachments/assets/186bfa6b-3c2f-495e-8f82-f2c742b761c6)

### Verification

- `cargo fmt --manifest-path frame-app/Cargo.toml --check`
- `cargo test --manifest-path frame-app/Cargo.toml notifications::tests::conversion_notification_summary_pluralizes_file_and_error_counts -- --exact`
- `cargo test --manifest-path frame-app/Cargo.toml` — 672 passed, 6 ignored
- `cargo xtask ci` — passed in a temporary checkout with the Clippy-gate commit from #71 layered on `c00cf86`

Running Clippy directly on the independent branch reaches the three pre-existing Rust 1.95 warnings addressed separately by #71. The temporary combined run verifies the complete contributor gate without adding those unrelated fixes to this PR.
