### PR TITLE
Add structured bug and feature request forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug report
+description: Report reproducible Frame behavior that differs from what you expected.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please share the smallest reproducible case you can. Clear details make it easier to confirm what is happening.
+
+  - type: input
+    id: frame-version
+    attributes:
+      label: Frame version
+      description: Find this in Frame's About dialog or on the downloaded release.
+      placeholder: e.g. 0.31.1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system-version
+    attributes:
+      label: Operating system version
+      placeholder: e.g. macOS 15.5, Windows 11 24H2, or Ubuntu 24.04
+    validations:
+      required: true
+
+  - type: textarea
+    id: source-media
+    attributes:
+      label: Source media details
+      description: For media-related bugs, include the container, codecs, resolution, duration, and file size. Otherwise, write N/A.
+      placeholder: Container, video/audio codecs, resolution, duration, and file size
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Start from opening Frame and include the settings needed to trigger the problem.
+      placeholder: |
+        1. Open Frame
+        2. Add ...
+        3. Choose ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: ffmpeg-logs
+    attributes:
+      label: FFmpeg logs
+      description: For conversion bugs, paste the relevant output from Frame's Logs view. Otherwise, write N/A.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add screenshots, screen recordings, sample media links, or any other useful context.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+        - label: I agree to follow this project's Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Suggest an improvement to Frame or a new workflow it could support.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem first, then the outcome that would make the workflow better.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or limitation
+      description: What are you trying to do, and what makes it difficult today?
+      placeholder: I am trying to ... but ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or outcome you would like Frame to provide.
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow-context
+    attributes:
+      label: Workflow and media context
+      description: Include relevant formats, codecs, platforms, batch sizes, or other workflow constraints.
+
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Relevant platforms
+      multiple: true
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - All platforms
+        - Not sure
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Share any workarounds or different approaches you have tried.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add sketches, screenshots, sample media links, or related issues if useful.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched the existing issues and did not find a duplicate request.
+          required: true
+        - label: I agree to follow this project's Code of Conduct.
+          required: true


### PR DESCRIPTION
Bug reports and feature requests now guide people toward the details needed to understand and act on them.

- Adds a bug form for environment, media, reproduction, expected and actual behavior, FFmpeg logs, and supporting context.
- Adds a feature form centered on the problem, proposed outcome, workflow context, platforms, and alternatives.
- Requires duplicate-search and Code of Conduct confirmations.
- Preserves blank issues by leaving the existing configuration unchanged.

Closes #79.

### Actual screenshots

Before — upstream revision `affa1fb`:

![Only config.yml exists while CONTRIBUTING.md requests environment, media, reproduction, and log details](https://github.com/user-attachments/assets/4372c419-4bc5-4633-a1ac-9dc182f10c60)

After — revision `60ebb29`:

![The bug and feature forms are present and all three issue-template YAML files parse successfully](https://github.com/user-attachments/assets/8ca1611f-009c-4af9-81f8-7584ea008199)

### Verification

- Parsed every `.github/ISSUE_TEMPLATE/*.yml` file with Ruby's YAML parser.
- Checked both forms for required top-level keys, supported body types, and unique field IDs.
- `cargo xtask workflows` — generated no tracked changes.
- `cargo xtask ci` — passed in a temporary checkout with the Clippy-gate commit from #71 layered on `60ebb29`.

The temporary combined CI run keeps the pre-existing Rust 1.95 Clippy warnings and their fix out of this configuration-only PR.
