### PR TITLE
ci: run cargo xtask ci for pull requests

### DIFF
--- a/frame-app/src/app/runtime.rs
+++ b/frame-app/src/app/runtime.rs
@@ -86,24 +86,14 @@ pub fn frame_window_options(bounds: Bounds<Pixels>) -> WindowOptions {
         window_min_size: Some(size(px(WINDOW_MIN_WIDTH), px(WINDOW_MIN_HEIGHT))),
         window_background: WindowBackgroundAppearance::Opaque,
         window_decorations: Some(WindowDecorations::Client),
-        client_side_frame: linux_client_side_frame(),
+        client_side_frame: cfg!(target_os = "linux").then_some(ClientSideFrameOptions {
+            corner_radius: px(theme::RADIUS_LG + crate::LINUX_WINDOW_FRAME_INSET),
+        }),
         app_id: Some(FRAME_APP_ID.to_owned()),
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         icon: frame_window_icon(),
         ..Default::default()
     }
-}
-
-#[cfg(target_os = "linux")]
-const fn linux_client_side_frame() -> Option<ClientSideFrameOptions> {
-    Some(ClientSideFrameOptions {
-        corner_radius: px(theme::RADIUS_LG + LINUX_WINDOW_FRAME_INSET),
-    })
-}
-
-#[cfg(not(target_os = "linux"))]
-const fn linux_client_side_frame() -> Option<ClientSideFrameOptions> {
-    None
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]


### PR DESCRIPTION
Pull requests currently have no repository-owned check for Frame's documented contributor gate.

This adds one small generated workflow so routine pull requests get the same checks contributors run locally.

## What changed

- generate `.github/workflows/ci.yml` through `cargo xtask workflows`
- run on pull requests and pushes to `master`
- install the Ubuntu libraries required by the workspace
- run the documented `cargo xtask ci` gate
- keep repository permissions read-only and avoid persisting checkout credentials
- cancel superseded runs on the same branch or pull request
- cover the generated trigger, permissions, dependencies, and command with an xtask test
- keep two Linux-only paths Clippy-clean so the stable Linux gate can pass: updater install-root fallthrough and client-side frame configuration

Closes #85.

## Observable behavior

- Current: a pull request can have no repository-owned build, test, or Clippy check.
- Expected: pull requests receive a `cargo xtask ci` job, and the same gate runs after a push to `master`.

## Actual screenshots

Current checks on pull request #84 show only the third-party GitGuardian scan:

<img width="1512" height="752" alt="Pull request Checks page showing only GitGuardian and no repository CI job" src="https://github.com/user-attachments/assets/1a20894e-f45b-4f19-8c05-5891f02d3b69" />

Live after evidence on commit `35aceb9` shows the Ubuntu `cargo xtask ci` job succeeding in 7m 46s:

<img width="1512" height="696" alt="GitHub Actions job page showing cargo xtask ci succeeded on Ubuntu" src="https://github.com/user-attachments/assets/7456ae3e-078d-4687-8c3a-1a466362d9bc" />

The generated-workflow regression test passes on commit `2f61e2a`:

<img width="1331" height="768" alt="VS Code terminal showing the generated CI workflow regression test passing" src="https://github.com/user-attachments/assets/234a427b-079b-46f2-944c-9c6c0209e29b" />

The first two live runs exposed existing `needless_return` and `unnecessary_wraps` warnings in Linux-only code that macOS never compiles. The focused expression cleanups preserve behavior and were required for the final live run to pass.

## Verification

- `cargo xtask workflows`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses successfully"'`
- `cargo test --manifest-path tooling/xtask/Cargo.toml ci_workflow_runs_documented_gate_on_pull_requests_and_master -- --nocapture`
- `cargo test --manifest-path tooling/xtask/Cargo.toml`
- `cargo test -p frame-updater`
- `cargo clippy -p frame-updater --all-targets --locked -- -D warnings`
- `cargo test -p frame-app frame_window_options`
- `cargo clippy -p frame-app --all-targets --locked -- -D warnings`
- `cargo clippy --manifest-path tooling/xtask/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo xtask ci`
- `git diff --check`
