### PR TITLE
fix(app): resolve Linux clippy failure

### DIFF
--- a/frame-app/src/app/mod.rs
+++ b/frame-app/src/app/mod.rs
@@ -153,18 +153,18 @@ use frame_core::events::ConversionEvent;
 use frame_core::types::DEFAULT_MAX_CONCURRENCY;
 use frame_updater::{DownloadProgress, UpdateChannel, UpdateCheck, UpdateInfo, UpdatePackage};
 use gpui::{
-    App, Bounds, BoxShadow, ClickEvent, ClientSideFrameOptions, ClipboardItem, Context,
-    DispatchPhase, DragMoveEvent, Element, ElementId, ElementInputHandler, Entity,
-    EntityInputHandler, ExternalPaths, FileDropEvent, FocusHandle, GlobalElementId,
-    InteractiveElement, IntoElement, KeyBinding, LayoutId, Lerp, Menu, MenuItem, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, ObjectFit, PaintQuad, PinchEvent, Pixels,
-    PlatformInput, Point, Position, PromptButton, PromptLevel, Render, RenderImage, Rgba,
-    ScrollDelta, ScrollHandle, ScrollStrategy, ScrollWheelEvent, ShapedLine, SharedString,
-    StatefulInteractiveElement, Style, Task, TextRenderingMode, TextRun, TitlebarOptions,
-    TransformationMatrix, UTF16Selection, UniformListScrollHandle, Window,
-    WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowDecorations, WindowOptions,
-    actions, canvas, deferred, div, ease_in_out, fill, hsla, img, linear_color_stop,
-    linear_gradient, point, prelude::*, px, radians, relative, size, svg, uniform_list,
+    App, Bounds, BoxShadow, ClickEvent, ClipboardItem, Context, DispatchPhase, DragMoveEvent,
+    Element, ElementId, ElementInputHandler, Entity, EntityInputHandler, ExternalPaths,
+    FileDropEvent, FocusHandle, GlobalElementId, InteractiveElement, IntoElement, KeyBinding,
+    LayoutId, Lerp, Menu, MenuItem, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    ObjectFit, PaintQuad, PinchEvent, Pixels, PlatformInput, Point, Position, PromptButton,
+    PromptLevel, Render, RenderImage, Rgba, ScrollDelta, ScrollHandle, ScrollStrategy,
+    ScrollWheelEvent, ShapedLine, SharedString, StatefulInteractiveElement, Style, Task,
+    TextRenderingMode, TextRun, TitlebarOptions, TransformationMatrix, UTF16Selection,
+    UniformListScrollHandle, Window, WindowBackgroundAppearance, WindowBounds, WindowControlArea,
+    WindowDecorations, WindowOptions, actions, canvas, deferred, div, ease_in_out, fill, hsla, img,
+    linear_color_stop, linear_gradient, point, prelude::*, px, radians, relative, size, svg,
+    uniform_list,
 };
 use std::{
     ops::Range,

--- a/frame-app/src/app/runtime.rs
+++ b/frame-app/src/app/runtime.rs
@@ -86,24 +86,17 @@ pub fn frame_window_options(bounds: Bounds<Pixels>) -> WindowOptions {
         window_min_size: Some(size(px(WINDOW_MIN_WIDTH), px(WINDOW_MIN_HEIGHT))),
         window_background: WindowBackgroundAppearance::Opaque,
         window_decorations: Some(WindowDecorations::Client),
-        client_side_frame: linux_client_side_frame(),
+        #[cfg(target_os = "linux")]
+        client_side_frame: Some(gpui::ClientSideFrameOptions {
+            corner_radius: px(theme::RADIUS_LG + LINUX_WINDOW_FRAME_INSET),
+        }),
+        #[cfg(not(target_os = "linux"))]
+        client_side_frame: None,
         app_id: Some(FRAME_APP_ID.to_owned()),
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         icon: frame_window_icon(),
         ..Default::default()
     }
-}
-
-#[cfg(target_os = "linux")]
-const fn linux_client_side_frame() -> Option<ClientSideFrameOptions> {
-    Some(ClientSideFrameOptions {
-        corner_radius: px(theme::RADIUS_LG + LINUX_WINDOW_FRAME_INSET),
-    })
-}
-
-#[cfg(not(target_os = "linux"))]
-const fn linux_client_side_frame() -> Option<ClientSideFrameOptions> {
-    None
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]


### PR DESCRIPTION
## Summary

- replaces the cfg-specific Option helper with cfg-specific window field values
- removes the shared import that becomes unused outside Linux

## Root cause

Rust 1.95 Clippy evaluates the Linux-only helper after cfg selection and reports that its Option return is unnecessarily wrapped because the Linux implementation always returns Some.

## Validation

- cargo test --manifest-path frame-app/Cargo.toml --locked
- cargo clippy --manifest-path frame-app/Cargo.toml --all-targets --locked -- -D warnings
- cargo xtask ci

The Linux-specific path is left for GitHub Actions to verify on its native runner.