### PR TITLE
fix: carry rounded timecode boundaries

### DIFF
--- a/frame-app/src/preview/tests.rs
+++ b/frame-app/src/preview/tests.rs
@@ -492,6 +492,12 @@ mod time_formatting {
     fn format_time_pads_single_digit_seconds() {
         assert_eq!(super::super::format_time(61.2), "00:01:01.200");
     }
+
+    #[test]
+    fn format_time_carries_rounded_seconds_across_timecode_boundaries() {
+        assert_eq!(super::super::format_time(59.9999), "00:01:00.000");
+        assert_eq!(super::super::format_time(3599.9999), "01:00:00.000");
+    }
 }
 
 mod preview_playback_state {

--- a/frame-app/src/preview/timeline.rs
+++ b/frame-app/src/preview/timeline.rs
@@ -459,9 +459,10 @@ pub fn parse_time_to_seconds(time: &str) -> f64 {
 
 #[must_use]
 pub fn format_time(seconds: f64) -> String {
-    let hours = (seconds / 3600.0).floor();
-    let minutes = ((seconds % 3600.0) / 60.0).floor();
-    let seconds = seconds % 60.0;
+    let rounded_seconds = (seconds * 1000.0).round() / 1000.0;
+    let hours = (rounded_seconds / 3600.0).floor();
+    let minutes = ((rounded_seconds % 3600.0) / 60.0).floor();
+    let seconds = rounded_seconds % 60.0;
 
     format!("{hours:02.0}:{minutes:02.0}:{seconds:06.3}")
 }


### PR DESCRIPTION
Preview timecodes can display invalid `...:60.000` values when millisecond rounding crosses a minute or hour boundary.

## What changed

- Round the total duration to the displayed millisecond precision before splitting it into hours, minutes, and seconds.
- Add regression coverage for both minute and hour carry boundaries.

## Observable behavior

- Sequence: format a preview position of `59.9999` seconds.
- Expected: `00:01:00.000`
- Previous result: `00:00:60.000`

The same issue occurred at hour boundaries, where `3599.9999` seconds could render as `00:59:60.000` instead of `01:00:00.000`.

## Validation

- `cargo xtask ci`
- `cargo test --manifest-path frame-app/Cargo.toml preview::tests::time_formatting:: -- --nocapture`
