### PR TITLE
fix(release): correct workflow shell and permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         persist-credentials: false
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
         required: true
 permissions:
   contents: read
+  actions: read
 concurrency:
   group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
   cancel-in-progress: false
@@ -124,6 +125,7 @@ jobs:
     - name: release::check_public_key
       run: test -n "$FRAME_UPDATE_PUBLIC_KEY"
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -183,6 +185,7 @@ jobs:
     - name: release::check_public_key
       run: test -n "$FRAME_UPDATE_PUBLIC_KEY"
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -244,6 +247,7 @@ jobs:
     - name: release::check_public_key
       run: test -n "$FRAME_UPDATE_PUBLIC_KEY"
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -324,6 +328,7 @@ jobs:
     - name: release::check_public_key
       run: test -n "$FRAME_UPDATE_PUBLIC_KEY"
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -406,6 +411,7 @@ jobs:
       run: |
         if (-not $env:FRAME_UPDATE_PUBLIC_KEY) { throw "FRAME_UPDATE_PUBLIC_KEY is required" }
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -484,6 +490,7 @@ jobs:
         persist-credentials: false
         ref: ${{ needs.prepare_release.outputs.commit_sha }}
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -868,6 +875,7 @@ jobs:
         ref: ${{ needs.prepare_release.outputs.commit_sha }}
     - name: steps::setup_rust
       if: steps.flathub_token.outputs.configured == 'true'
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0

--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         persist-credentials: false
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -83,6 +84,7 @@ jobs:
       with:
         persist-credentials: false
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -140,6 +142,7 @@ jobs:
       with:
         persist-credentials: false
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -175,6 +178,7 @@ jobs:
       with:
         persist-credentials: false
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0
@@ -210,6 +214,7 @@ jobs:
       with:
         persist-credentials: false
     - name: steps::setup_rust
+      shell: bash
       run: |
         rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
         rustup default 1.95.0

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -1534,7 +1534,7 @@ fn pin_workflow_tools(workflow: &mut String) {
     *workflow = workflow.replace(
         &rust_install,
         &format!(
-            "      run: |\n        rustup toolchain install {RUST_VERSION} --profile minimal --component clippy,rustfmt\n        rustup default {RUST_VERSION}\n        test \"$(rustc --version | awk '{{print $2}}')\" = \"{RUST_VERSION}\""
+            "      shell: bash\n      run: |\n        rustup toolchain install {RUST_VERSION} --profile minimal --component clippy,rustfmt\n        rustup default {RUST_VERSION}\n        test \"$(rustc --version | awk '{{print $2}}')\" = \"{RUST_VERSION}\""
         ),
     );
     *workflow = workflow.replace(
@@ -1979,6 +1979,7 @@ on:
         required: true
 permissions:
   contents: read
+  actions: read
 concurrency:
   group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
   cancel-in-progress: false
@@ -3761,6 +3762,7 @@ mod tests {
         }
 
         let release = release_workflow();
+        assert_eq!(release.matches("  actions: read").count(), 1);
         assert_eq!(release.matches("      contents: write").count(), 1);
         assert_eq!(release.matches("      id-token: write").count(), 1);
         assert_eq!(release.matches("      attestations: write").count(), 1);
@@ -3811,6 +3813,21 @@ mod tests {
                     .count(),
                 "every Rust installation in {path} must verify the active version"
             );
+            let rust_setup_count = workflow.matches("    - name: steps::setup_rust").count();
+            assert_eq!(
+                rust_install_count, rust_setup_count,
+                "every Rust installation in {path} must belong to a setup step"
+            );
+            for block in workflow
+                .split("    - name: steps::setup_rust")
+                .skip(1)
+                .map(|remainder| remainder.split("    - name:").next().unwrap())
+            {
+                assert!(
+                    block.contains("\n      shell: bash\n"),
+                    "every Rust setup in {path} must use an explicit cross-platform shell"
+                );
+            }
 
             let nix_action_count = workflow.matches("uses: cachix/install-nix-action@").count();
             let pinned_nix_count = workflow


### PR DESCRIPTION
- Added `actions: read` so the release workflow can verify successful CI runs.
- Made every generated Rust setup step explicitly use Bash, including on Windows runners.
- Added generator tests preventing either requirement from being lost during workflow regeneration.
- Regenerated the committed workflow files from `xtask`.