### PR TITLE
feat: virtualize workspace file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Virtualized File Queue:** Reused the Logs panel's uniform-list rendering and scrollbar for the workspace file queue, keeping large batches responsive while preserving row selection, actions, and accessibility.
 - **Subtitle Settings Workflow:** Split the Subtitles tab into Selectable and Burn-in modes so only the relevant controls are shown. Selectable subtitles now combine imported sidecars with embedded source tracks, while burn-in import uses the same post-import file-row and removal pattern as selectable subtitles.
 - **Audio and Subtitle Track Rows:** Reworked shared track rows so audio metadata uses a readable two-line layout with channels, language, track name, and bitrate grouped together, while subtitle rows remain compact and preserve the track index and codec when space is limited. Source track names now fall back to FFmpeg handler metadata when no title is available.
 

--- a/frame-app/src/app/file_list_panel.rs
+++ b/frame-app/src/app/file_list_panel.rs
@@ -3,25 +3,27 @@ use super::{
     FILE_LIST_ACTION_ICON_SIZE, FILE_LIST_ACTIONS_WIDTH, FILE_ROW_HEIGHT, FileItem, FileQueue,
     FileStateTone, FluentBuilder, FrameRoot, InteractiveElement, IntoElement, MouseButton,
     PANEL_HEADER_HEIGHT, ParentElement, Rgba, RowActionAvailability, RowPrimaryAction,
-    RowSecondaryAction, StatefulInteractiveElement, Styled, WORKSPACE_GAP, Window, assets, div,
-    format_file_size, theme,
+    RowSecondaryAction, StatefulInteractiveElement, Styled, UniformListScrollHandle, WORKSPACE_GAP,
+    Window, assets, div, format_file_size, theme, uniform_list,
 };
 use super::{
     accessibility::apply_accessible_checkbox,
     components::{
         FrameIconButtonSize, FrameIconButtonVariant, frame_checkbox_indicator, frame_icon_button,
+        frame_vertical_uniform_scrollbar,
     },
     primitives::{
         FrameSurface, button_mouse_down, color, drop_target_shadows, element_id,
         panel_bottom_separator,
     },
 };
+use crate::numeric::usize_to_f32;
 
 pub(super) fn file_list_panel(
     queue: &FileQueue,
+    scroll_handle: &UniformListScrollHandle,
     palette: &'static theme::ThemePalette,
-    window: &mut Window,
-    cx: &mut Context<FrameRoot>,
+    cx: &Context<FrameRoot>,
 ) -> gpui::Div {
     div()
         .flex()
@@ -36,7 +38,7 @@ pub(super) fn file_list_panel(
                 .shadow(drop_target_shadows(palette))
         })
         .child(file_list_header(queue.batch_selection_state(), palette, cx))
-        .child(file_list_body(queue, palette, window, cx))
+        .child(file_list_body(queue, scroll_handle, palette, cx))
 }
 
 pub(super) fn file_list_header(
@@ -137,18 +139,19 @@ pub(super) fn file_list_header(
 
 pub(super) fn file_list_body(
     queue: &FileQueue,
+    scroll_handle: &UniformListScrollHandle,
     palette: &'static theme::ThemePalette,
-    window: &mut Window,
-    cx: &mut Context<FrameRoot>,
+    cx: &Context<FrameRoot>,
 ) -> impl IntoElement {
     let body = div()
         .id("file-list-body")
         .role(gpui::Role::List)
         .aria_label("File queue")
+        .relative()
         .flex_1()
         .flex()
         .flex_col()
-        .overflow_y_scroll();
+        .overflow_hidden();
     if queue.files().is_empty() {
         return body.child(
             div()
@@ -162,17 +165,35 @@ pub(super) fn file_list_body(
         );
     }
 
-    let mut body = body;
-    for file in queue.files() {
-        body = body.child(file_list_row(
-            file,
-            queue.selected_file_id() == Some(file.id.as_str()),
-            palette,
-            window,
-            cx,
-        ));
-    }
-    body
+    let file_count = queue.files().len();
+    let list = uniform_list(
+        "file-list-rows",
+        file_count,
+        cx.processor(move |root, range: std::ops::Range<usize>, window, cx| {
+            let selected_id = root.file_queue.selected_file_id();
+            range
+                .filter_map(|index| root.file_queue.files().get(index))
+                .map(|file| {
+                    file_list_row(
+                        file,
+                        selected_id == Some(file.id.as_str()),
+                        palette,
+                        window,
+                        cx,
+                    )
+                })
+                .collect()
+        }),
+    )
+    .track_scroll(scroll_handle)
+    .size_full();
+
+    body.child(list).child(frame_vertical_uniform_scrollbar(
+        "file-list-scrollbar",
+        scroll_handle,
+        usize_to_f32(file_count) * FILE_ROW_HEIGHT,
+        palette,
+    ))
 }
 
 pub(super) fn file_list_row(
@@ -181,7 +202,7 @@ pub(super) fn file_list_row(
     palette: &'static theme::ThemePalette,
     window: &mut Window,
     cx: &mut Context<FrameRoot>,
-) -> impl IntoElement {
+) -> gpui::Stateful<gpui::Div> {
     let group_name = format!("file-list-row-{}", file.id);
     let select_id = file.id.clone();
     let row_accessible_label = format!(

--- a/frame-app/src/app/fixtures.rs
+++ b/frame-app/src/app/fixtures.rs
@@ -74,6 +74,9 @@ impl FrameRoot {
             Some(VisualFixture::WorkspaceAudio) => self.apply_workspace_audio_fixture(),
             Some(VisualFixture::WorkspaceEmpty) => self.apply_workspace_empty_fixture(),
             Some(VisualFixture::WorkspaceImage) => self.apply_workspace_image_fixture(),
+            Some(VisualFixture::WorkspaceLargeQueue) => {
+                self.apply_workspace_large_queue_fixture();
+            }
             None => {}
         }
     }
@@ -112,6 +115,18 @@ impl FrameRoot {
     pub(super) fn apply_workspace_image_fixture(&mut self) {
         self.seed_image_source_fixture();
         self.settings_ui.active_tab = SettingsTab::Source;
+    }
+    pub(super) fn apply_workspace_large_queue_fixture(&mut self) {
+        const FILE_COUNT: usize = 500;
+
+        self.apply_preview_ready_fixture();
+        self.file_queue.add_files((1..FILE_COUNT).map(|index| {
+            FileItem::from_path(
+                format!("fixture-queue-{index:03}"),
+                format!("/tmp/render_queue_item_{index:03}.mov"),
+                32_000_000 + index as u64 * 1_250_000,
+            )
+        }));
     }
     pub(super) fn apply_logs_active_fixture(&mut self) {
         self.active_view = ActiveView::Logs;

--- a/frame-app/src/app/mod.rs
+++ b/frame-app/src/app/mod.rs
@@ -264,6 +264,7 @@ pub struct FrameRoot {
     titlebar_drag: TitlebarDragState,
     focus_registry: FrameFocusRegistry,
     file_queue: FileQueue,
+    file_list_scroll_handle: UniformListScrollHandle,
     conversion_events: ConversionEventState,
     logs_scroll_handle: UniformListScrollHandle,
     last_log_scroll_target: Option<LogScrollTarget>,

--- a/frame-app/src/app/render.rs
+++ b/frame-app/src/app/render.rs
@@ -478,6 +478,7 @@ impl Render for FrameRoot {
                 };
                 content.child(workspace_view(
                     &self.file_queue,
+                    &self.file_list_scroll_handle,
                     &settings,
                     PreviewPanelProps {
                         canvas: preview_canvas,

--- a/frame-app/src/app/state.rs
+++ b/frame-app/src/app/state.rs
@@ -93,6 +93,7 @@ impl FrameRoot {
             titlebar_drag: TitlebarDragState::default(),
             focus_registry: FrameFocusRegistry::default(),
             file_queue: FileQueue::new(),
+            file_list_scroll_handle: UniformListScrollHandle::new(),
             conversion_events: ConversionEventState::new(),
             logs_scroll_handle: UniformListScrollHandle::new(),
             last_log_scroll_target: None,

--- a/frame-app/src/app/tests.rs
+++ b/frame-app/src/app/tests.rs
@@ -3654,6 +3654,15 @@ mod visual_fixtures {
     }
 
     #[test]
+    fn workspace_large_queue_fixture_seeds_many_files_for_virtualization_checks() {
+        let mut root = FrameRoot::new();
+
+        root.apply_visual_fixture(Some(VisualFixture::WorkspaceLargeQueue));
+
+        assert_eq!(root.file_queue.files().len(), 500);
+    }
+
+    #[test]
     fn settings_source_fixture_opens_source_tab_with_ready_metadata() {
         let mut root = FrameRoot::new();
 

--- a/frame-app/src/app/workspace.rs
+++ b/frame-app/src/app/workspace.rs
@@ -1,8 +1,8 @@
 use super::{
     ClickEvent, Context, FILE_LIST_ROW_SPAN, FileQueue, FrameRoot, LEFT_COLUMN_SPAN,
     LEFT_GRID_ROWS, PREVIEW_ROW_SPAN, ParentElement, PreviewPanelProps, RIGHT_COLUMN_SPAN,
-    SettingsRenderState, StatefulInteractiveElement, Styled, WORKSPACE_COLUMNS, WORKSPACE_GAP,
-    Window, assets, color, div, svg, theme,
+    SettingsRenderState, StatefulInteractiveElement, Styled, UniformListScrollHandle,
+    WORKSPACE_COLUMNS, WORKSPACE_GAP, Window, assets, color, div, svg, theme,
 };
 use super::{
     file_list_panel::file_list_panel,
@@ -18,6 +18,7 @@ const WELCOME_MAX_WIDTH: f32 = 420.0;
 
 pub(super) fn workspace_view(
     file_queue: &FileQueue,
+    file_list_scroll_handle: &UniformListScrollHandle,
     settings: &SettingsRenderState<'_>,
     preview_props: PreviewPanelProps<'_>,
     window: &mut Window,
@@ -44,7 +45,7 @@ pub(super) fn workspace_view(
                         .row_span(PREVIEW_ROW_SPAN),
                 )
                 .child(
-                    file_list_panel(file_queue, settings.palette, window, cx)
+                    file_list_panel(file_queue, file_list_scroll_handle, settings.palette, cx)
                         .row_span(FILE_LIST_ROW_SPAN),
                 ),
         )

--- a/frame-app/src/lib.rs
+++ b/frame-app/src/lib.rs
@@ -115,6 +115,7 @@ pub enum VisualFixture {
     WorkspaceAudio,
     WorkspaceEmpty,
     WorkspaceImage,
+    WorkspaceLargeQueue,
 }
 
 #[must_use]
@@ -141,6 +142,7 @@ pub fn visual_fixture_from_env_value(value: Option<&str>) -> Option<VisualFixtur
         Some("workspace-audio") => Some(VisualFixture::WorkspaceAudio),
         Some("workspace-empty") => Some(VisualFixture::WorkspaceEmpty),
         Some("workspace-image") => Some(VisualFixture::WorkspaceImage),
+        Some("workspace-large-queue") => Some(VisualFixture::WorkspaceLargeQueue),
         _ => None,
     }
 }
@@ -340,6 +342,7 @@ mod tests {
                 ("workspace-audio", VisualFixture::WorkspaceAudio),
                 ("workspace-empty", VisualFixture::WorkspaceEmpty),
                 ("workspace-image", VisualFixture::WorkspaceImage),
+                ("workspace-large-queue", VisualFixture::WorkspaceLargeQueue),
             ];
 
             for (value, expected) in cases {


### PR DESCRIPTION
## Summary

- render the workspace file queue with GPUI uniform_list and the same custom scrollbar used by Logs
- preserve existing row selection, actions, hover/focus behavior, and accessibility metadata
- add a workspace-large-queue visual fixture containing 500 files for manual and automated checks
- document the change in the Unreleased changelog

## Validation

- cargo xtask ci
- manual visual check at the top and bottom of the 500-file fixture