### PR TITLE
chore(release): prepare 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-08-04
+
 ### Added
 
 - **M2T, MTS, and M2TS Workflows:** Added complete MPEG transport-stream import, preview, re-encode, mixed subtitle, and stream-copy workflows with explicit 188-byte M2T and 192-byte MTS/M2TS profiles; MPEG-2 Video, MP2, Opus-in-TS, AC-3, and Blu-ray PCM encoding; program/service metadata Preserve, Clean, and Replace modes; SRT/ASS/WebVTT burn-in; embedded DVB/teletext/ARIB/PGS handling; and selectable `.sup` PGS copy or standards-compliant DVB conversion without private-data subtitle fallbacks. Resolves [#111](https://github.com/66HEX/frame/issues/111).
@@ -856,7 +858,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic media metadata probing via FFprobe.
 - Preset-based configuration system.
 
-[Unreleased]: https://github.com/66HEX/frame/compare/0.32.0...HEAD
+[Unreleased]: https://github.com/66HEX/frame/compare/0.33.0...HEAD
+[0.33.0]: https://github.com/66HEX/frame/compare/0.32.0...0.33.0
 [0.32.0]: https://github.com/66HEX/frame/compare/0.31.1...0.32.0
 [0.31.1]: https://github.com/66HEX/frame/compare/0.31.0...0.31.1
 [0.31.0]: https://github.com/66HEX/frame/compare/0.30.0...0.31.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "frame-app"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "ashpd",
  "cpal",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "frame-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "font-kit",
  "regex",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "frame-updater"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "base64 0.23.0",
  "directories",

--- a/frame-app/Cargo.toml
+++ b/frame-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-app"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2024"
 authors = ["Marek Jozwiak <hexthecoder@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/frame-core/Cargo.toml
+++ b/frame-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-core"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2024"
 authors = ["Marek Jozwiak <hexthecoder@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/frame-updater/Cargo.toml
+++ b/frame-updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-updater"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2024"
 authors = ["Marek Jozwiak <hexthecoder@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/inno/frame.iss
+++ b/inno/frame.iss
@@ -6,7 +6,7 @@
 #define AppSetupName "Frame-x86_64"
 #endif
 #ifndef AppVersion
-#define AppVersion "0.32.0"
+#define AppVersion "0.33.0"
 #endif
 #ifndef OutputDir
 #define OutputDir "..\target"

--- a/packaging/flathub/io.github._66HEX.Frame.metainfo.xml
+++ b/packaging/flathub/io.github._66HEX.Frame.metainfo.xml
@@ -29,6 +29,6 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="0.32.0" date="2026-07-26" />
+    <release version="0.33.0" date="2026-08-04" />
   </releases>
 </component>

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -4406,7 +4406,7 @@ mod tests {
         let metainfo =
             include_str!("../../../packaging/flathub/io.github._66HEX.Frame.metainfo.xml");
 
-        assert!(metainfo.contains(r#"<release version="0.32.0" date="2026-07-26" />"#));
+        assert!(metainfo.contains(r#"<release version="0.33.0" date="2026-08-04" />"#));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- bump Frame application, core, updater, and installer versions to 0.33.0
- finalize the 0.33.0 changelog and comparison links
- update Flathub release metadata and release validation fixture

## Validation

- `git diff --check`
- `cargo xtask workflows --check`