### PR TITLE
fix(windows): restore 0.33.0 release builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       timezone: Europe/Warsaw
     open-pull-requests-limit: 10
     groups:
+      windows-rs:
+        patterns:
+          - windows
+          - windows-core
+          - windows-numerics
       rust-patch-updates:
         update-types:
           - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,20 @@ jobs:
     - name: ci::run_documented_gate
       run: cargo xtask ci
     timeout-minutes: 60
+  cargo_check_windows:
+    name: cargo check windows
+    runs-on: windows-2022
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - name: steps::setup_rust
+      shell: bash
+      run: |
+        rustup toolchain install 1.95.0 --profile minimal --component clippy,rustfmt
+        rustup default 1.95.0
+        test "$(rustc --version | awk '{print $2}')" = "1.95.0"
+    - name: ci::check_windows
+      run: cargo check --manifest-path frame-app/Cargo.toml --target x86_64-pc-windows-msvc --locked
+    timeout-minutes: 60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
  "util",
  "uuid",
  "windows 0.61.3",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
  "windows-numerics 0.2.0",
  "windows-registry",
 ]

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -1996,6 +1996,19 @@ jobs:
     - name: ci::run_documented_gate
       run: cargo xtask ci
     timeout-minutes: 60
+  cargo_check_windows:
+    name: cargo check windows
+    runs-on: windows-2022
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@v7.0.0
+      with:
+        persist-credentials: false
+    - name: steps::setup_rust
+      run: rustup toolchain install __RUST_VERSION__ --profile minimal --component clippy,rustfmt
+    - name: ci::check_windows
+      run: cargo check --manifest-path frame-app/Cargo.toml --target x86_64-pc-windows-msvc --locked
+    timeout-minutes: 60
 ",
     )
 }
@@ -4302,6 +4315,33 @@ mod tests {
                 !workflow.contains(forbidden),
                 "release workflow contains mutable or overwrite path: {forbidden}"
             );
+        }
+    }
+
+    #[test]
+    fn ci_workflow_checks_the_windows_target_on_a_windows_runner() {
+        let workflow = ci_workflow();
+        let windows_job = workflow_job(&workflow, "cargo_check_windows");
+
+        assert!(windows_job.contains("runs-on: windows-2022"));
+        assert!(windows_job.contains(
+            "cargo check --manifest-path frame-app/Cargo.toml --target x86_64-pc-windows-msvc --locked"
+        ));
+    }
+
+    #[test]
+    fn dependabot_groups_the_windows_rs_dependency_family() {
+        let config = include_str!("../../../.github/dependabot.yml");
+        let windows_group = config
+            .split_once("      windows-rs:\n")
+            .unwrap()
+            .1
+            .split_once("      rust-patch-updates:\n")
+            .unwrap()
+            .0;
+
+        for dependency in ["windows", "windows-core", "windows-numerics"] {
+            assert!(windows_group.contains(&format!("          - {dependency}\n")));
         }
     }
 

--- a/vendor/gpui-ce/Cargo.toml
+++ b/vendor/gpui-ce/Cargo.toml
@@ -115,7 +115,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
   "NSGraphics",
 ] }
 semver = { version = "1.0", features = ["serde"] }
-windows-core = "0.62"
+windows-core = "0.61"
 tokio = { version = "1" }
 gpui_util = { git = "https://github.com/zed-industries/zed", rev = "876ec5a8a074ba83cce2129ed4d76b59c05a37e9" }
 


### PR DESCRIPTION
## Summary

- restore the compatible `windows 0.61` / `windows-core 0.61` pairing inside vendored GPUI
- group direct `windows`, `windows-core`, and `windows-numerics` updates in Dependabot
- add a native Windows compile job to the required CI workflow
- add generator tests that keep both safeguards in place

## Context

The first `0.33.0` release attempt failed because Dependabot PR #124 upgraded only `windows-core` inside GPUI to 0.62 while GPUI still used `windows` 0.61. The standard Linux CI did not compile Windows-only COM code.

## Validation

- `cargo xtask ci`
- `cargo xtask workflows --check`
- signed commits
- full `run-bundling` requested via label, including Windows installer

Closes the failed release run #30936993157.