### PR TITLE
feat: export current frame

### DIFF
--- a/frame-app/src/app/preview_actions.rs
+++ b/frame-app/src/app/preview_actions.rs
@@ -2010,12 +2010,12 @@ impl FrameRoot {
         let source_path = file_item.path.clone();
         let source_name = file_item.name.clone();
 
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let rounded_ms = (position * 1000.0).round() as u64;
-        let hours = rounded_ms / 3_600_000;
-        let minutes = (rounded_ms % 3_600_000) / 60_000;
-        let seconds = (rounded_ms % 60_000) / 1000;
-        let ms = rounded_ms % 1000;
+        let duration = std::time::Duration::from_secs_f64(position.max(0.0));
+        let hours = duration.as_secs() / 3600;
+        let minutes = (duration.as_secs() % 3600) / 60;
+        let seconds = duration.as_secs() % 60;
+        let ms = duration.subsec_millis();
+
         let base_name = source_name
             .rsplit_once('.')
             .map_or(&source_name as &str, |(n, _)| n);
@@ -2025,13 +2025,16 @@ impl FrameRoot {
         let _ = session.command(crate::preview_engine::PreviewCommand::Pause);
 
         let dialog = export_frame_dialog(window, &default_name);
-        cx.spawn(async move |_this, cx| {
+        cx.spawn(async move |_this, _cx| {
             let Some(dest_path) = pick_export_frame_path(dialog).await else {
                 return;
             };
 
-            cx.background_executor()
-                .spawn(async move {
+            let dest_path_str = dest_path.to_string_lossy().into_owned();
+
+            if let Err(error) = std::thread::Builder::new()
+                .name("export-frame".to_string())
+                .spawn(move || {
                     let mut cmd = Command::new(ffmpeg_executable());
                     cmd.arg("-y")
                         .arg("-ss")
@@ -2040,11 +2043,31 @@ impl FrameRoot {
                         .arg(&source_path)
                         .arg("-frames:v")
                         .arg("1")
-                        .arg(dest_path);
+                        .arg(&dest_path_str);
 
-                    let _ = cmd.output();
+                    match cmd.output() {
+                        Ok(output) if output.status.success() => {
+                            let _ = notify_rust::Notification::new()
+                                .appname(crate::app_info::FRAME_APP_NAME)
+                                .summary("Frame Exported")
+                                .body(&format!("Saved to {}", dest_path_str))
+                                .icon("frame")
+                                .show();
+                        }
+                        Ok(output) => {
+                            eprintln!(
+                                "Failed to export frame: {}",
+                                String::from_utf8_lossy(&output.stderr)
+                            );
+                        }
+                        Err(error) => {
+                            eprintln!("Failed to spawn ffmpeg for frame export: {error}");
+                        }
+                    }
                 })
-                .await;
+            {
+                eprintln!("Failed to spawn frame export thread: {error}");
+            }
         })
         .detach();
     }

--- a/frame-app/src/app/preview_actions.rs
+++ b/frame-app/src/app/preview_actions.rs
@@ -2004,10 +2004,19 @@ impl FrameRoot {
         
         let Some(file_item) = self.file_queue.selected_file() else { return; };
         let source_path = file_item.path.clone();
+        let source_name = file_item.name.clone();
+        
+        let rounded_ms = (position * 1000.0).round() as u64;
+        let hours = rounded_ms / 3600000;
+        let minutes = (rounded_ms % 3600000) / 60000;
+        let seconds = (rounded_ms % 60000) / 1000;
+        let ms = rounded_ms % 1000;
+        let base_name = source_name.rsplit_once('.').map(|(n, _)| n).unwrap_or(&source_name);
+        let default_name = format!("{base_name}_frame_{hours:02}h{minutes:02}m{seconds:02}s{ms:03}ms.png");
         
         let _ = session.command(crate::preview_engine::PreviewCommand::Pause);
         
-        let dialog = export_frame_dialog(window);
+        let dialog = export_frame_dialog(window, &default_name);
         cx.spawn(async move |_this, cx| {
             let Some(dest_path) = pick_export_frame_path(dialog).await else { return; };
             

--- a/frame-app/src/app/preview_actions.rs
+++ b/frame-app/src/app/preview_actions.rs
@@ -1,11 +1,11 @@
 use super::*;
 use crate::app::preview_panel::preview_presented_frame;
 use crate::conversion_runner::core_config_from_gpui;
+use crate::native_dialogs::{export_frame_dialog, pick_export_frame_path};
 use crate::numeric::rounded_f64_to_u64;
 use crate::preview_engine::PreviewEngineError;
-use crate::settings::{AudioFiltersConfig, FilterValue, VideoFiltersConfig};
 use crate::runtime_binaries::ffmpeg_executable;
-use crate::native_dialogs::{export_frame_dialog, pick_export_frame_path};
+use crate::settings::{AudioFiltersConfig, FilterValue, VideoFiltersConfig};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -1997,38 +1997,51 @@ impl FrameRoot {
             });
         self.settings_ui.active_tab = next_tab;
     }
-    pub(super) fn trigger_export_frame(&mut self, window: &Window, cx: &mut Context<Self>) {
-        let Some(session) = &self.preview_ui.session else { return; };
+    pub(super) fn trigger_export_frame(&self, window: &Window, cx: &Context<Self>) {
+        let Some(session) = &self.preview_ui.session else {
+            return;
+        };
         let snapshot = session.snapshot();
         let position = snapshot.playback.position_seconds;
-        
-        let Some(file_item) = self.file_queue.selected_file() else { return; };
+
+        let Some(file_item) = self.file_queue.selected_file() else {
+            return;
+        };
         let source_path = file_item.path.clone();
         let source_name = file_item.name.clone();
-        
+
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let rounded_ms = (position * 1000.0).round() as u64;
-        let hours = rounded_ms / 3600000;
-        let minutes = (rounded_ms % 3600000) / 60000;
-        let seconds = (rounded_ms % 60000) / 1000;
+        let hours = rounded_ms / 3_600_000;
+        let minutes = (rounded_ms % 3_600_000) / 60_000;
+        let seconds = (rounded_ms % 60_000) / 1000;
         let ms = rounded_ms % 1000;
-        let base_name = source_name.rsplit_once('.').map(|(n, _)| n).unwrap_or(&source_name);
-        let default_name = format!("{base_name}_frame_{hours:02}h{minutes:02}m{seconds:02}s{ms:03}ms.png");
-        
+        let base_name = source_name
+            .rsplit_once('.')
+            .map_or(&source_name as &str, |(n, _)| n);
+        let default_name =
+            format!("{base_name}_frame_{hours:02}h{minutes:02}m{seconds:02}s{ms:03}ms.png");
+
         let _ = session.command(crate::preview_engine::PreviewCommand::Pause);
-        
+
         let dialog = export_frame_dialog(window, &default_name);
         cx.spawn(async move |_this, cx| {
-            let Some(dest_path) = pick_export_frame_path(dialog).await else { return; };
-            
+            let Some(dest_path) = pick_export_frame_path(dialog).await else {
+                return;
+            };
+
             cx.background_executor()
                 .spawn(async move {
                     let mut cmd = Command::new(ffmpeg_executable());
                     cmd.arg("-y")
-                        .arg("-ss").arg(position.to_string())
-                        .arg("-i").arg(&source_path)
-                        .arg("-frames:v").arg("1")
+                        .arg("-ss")
+                        .arg(position.to_string())
+                        .arg("-i")
+                        .arg(&source_path)
+                        .arg("-frames:v")
+                        .arg("1")
                         .arg(dest_path);
-                    
+
                     let _ = cmd.output();
                 })
                 .await;

--- a/frame-app/src/app/preview_actions.rs
+++ b/frame-app/src/app/preview_actions.rs
@@ -4,9 +4,12 @@ use crate::conversion_runner::core_config_from_gpui;
 use crate::numeric::rounded_f64_to_u64;
 use crate::preview_engine::PreviewEngineError;
 use crate::settings::{AudioFiltersConfig, FilterValue, VideoFiltersConfig};
+use crate::runtime_binaries::ffmpeg_executable;
+use crate::native_dialogs::{export_frame_dialog, pick_export_frame_path};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
+    process::Command,
 };
 
 impl FrameRoot {
@@ -1993,6 +1996,35 @@ impl FrameRoot {
                 resolve_active_settings_tab(self.settings_ui.active_tab, config, metadata)
             });
         self.settings_ui.active_tab = next_tab;
+    }
+    pub(super) fn trigger_export_frame(&mut self, window: &Window, cx: &mut Context<Self>) {
+        let Some(session) = &self.preview_ui.session else { return; };
+        let snapshot = session.snapshot();
+        let position = snapshot.playback.position_seconds;
+        
+        let Some(file_item) = self.file_queue.selected_file() else { return; };
+        let source_path = file_item.path.clone();
+        
+        let _ = session.command(crate::preview_engine::PreviewCommand::Pause);
+        
+        let dialog = export_frame_dialog(window);
+        cx.spawn(async move |_this, cx| {
+            let Some(dest_path) = pick_export_frame_path(dialog).await else { return; };
+            
+            cx.background_executor()
+                .spawn(async move {
+                    let mut cmd = Command::new(ffmpeg_executable());
+                    cmd.arg("-y")
+                        .arg("-ss").arg(position.to_string())
+                        .arg("-i").arg(&source_path)
+                        .arg("-frames:v").arg("1")
+                        .arg(dest_path);
+                    
+                    let _ = cmd.output();
+                })
+                .await;
+        })
+        .detach();
     }
 }
 

--- a/frame-app/src/app/preview_panel/toolbar.rs
+++ b/frame-app/src/app/preview_panel/toolbar.rs
@@ -13,8 +13,8 @@ const PREVIEW_TOOLBAR_PADDING: f32 = 4.0;
 const PREVIEW_TOOLBAR_GAP: f32 = 8.0;
 const PREVIEW_TOOLBAR_VERTICAL_SEPARATOR_HEIGHT: f32 = 18.0;
 const PREVIEW_TOOLBAR_VERTICAL_SEPARATOR_WIDTH: f32 = 1.0;
-const PREVIEW_TOOLBAR_BUTTON_COUNT: f32 = 5.0;
-const PREVIEW_TOOLBAR_GAP_COUNT: f32 = 4.0;
+const PREVIEW_TOOLBAR_BUTTON_COUNT: f32 = 6.0;
+const PREVIEW_TOOLBAR_GAP_COUNT: f32 = 5.0;
 
 pub(in crate::app) const fn preview_toolbar_height() -> f32 {
     (PREVIEW_TOOLBAR_PADDING * 2.0)
@@ -138,6 +138,21 @@ pub(in crate::app) fn preview_toolbar(
                 if root.trigger_selected_overlay(window, cx) {
                     cx.notify();
                 }
+            })),
+        )
+        .child(
+            preview_tool_button(
+                "preview-tool-export-frame",
+                assets::ICON_DOWNLOAD_02,
+                "Export frame",
+                false,
+                transform_enabled, // We enable this when transform/visual controls are enabled
+                palette,
+                window,
+                cx,
+            )
+            .on_click(cx.listener(|root, _: &ClickEvent, window, cx| {
+                root.trigger_export_frame(window, cx);
             })),
         )
 }

--- a/frame-app/src/native_dialogs.rs
+++ b/frame-app/src/native_dialogs.rs
@@ -94,6 +94,23 @@ pub const OVERLAY_IMAGE_DIALOG_SPEC: NativeDialogSpec = NativeDialogSpec {
     allows_multiple: false,
 };
 
+pub const EXPORT_FRAME_DIALOG_FILTERS: [NativeDialogFilterSpec; 2] = [
+    NativeDialogFilterSpec {
+        label: "PNG Image",
+        extensions: &["png"],
+    },
+    NativeDialogFilterSpec {
+        label: "WebP Image",
+        extensions: &["webp"],
+    },
+];
+
+pub const EXPORT_FRAME_DIALOG_SPEC: NativeDialogSpec = NativeDialogSpec {
+    title: "Export Frame",
+    filters: &EXPORT_FRAME_DIALOG_FILTERS,
+    allows_multiple: false,
+};
+
 pub async fn pick_source_files(dialog: AsyncFileDialog) -> Option<Vec<PathBuf>> {
     dialog
         .pick_files()
@@ -160,6 +177,17 @@ pub fn external_subtitle_file_dialog(parent: &Window, container: &str) -> AsyncF
 #[must_use]
 pub fn overlay_image_dialog(parent: &Window) -> AsyncFileDialog {
     file_dialog_from_spec(OVERLAY_IMAGE_DIALOG_SPEC).set_parent(parent)
+}
+
+pub async fn pick_export_frame_path(dialog: AsyncFileDialog) -> Option<PathBuf> {
+    dialog.save_file().await.as_ref().map(file_handle_to_path)
+}
+
+#[must_use]
+pub fn export_frame_dialog(parent: &Window) -> AsyncFileDialog {
+    file_dialog_from_spec(EXPORT_FRAME_DIALOG_SPEC)
+        .set_parent(parent)
+        .set_file_name("frame.png")
 }
 
 fn file_dialog_from_spec(spec: NativeDialogSpec) -> AsyncFileDialog {
@@ -254,6 +282,7 @@ mod tests {
             assert!(!SUBTITLE_FILE_DIALOG_SPEC.allows_multiple);
             assert!(EXTERNAL_SUBTITLE_FILE_DIALOG_SPEC.allows_multiple);
             assert!(!OVERLAY_IMAGE_DIALOG_SPEC.allows_multiple);
+            assert!(!EXPORT_FRAME_DIALOG_SPEC.allows_multiple);
         }
     }
 

--- a/frame-app/src/native_dialogs.rs
+++ b/frame-app/src/native_dialogs.rs
@@ -184,10 +184,10 @@ pub async fn pick_export_frame_path(dialog: AsyncFileDialog) -> Option<PathBuf> 
 }
 
 #[must_use]
-pub fn export_frame_dialog(parent: &Window) -> AsyncFileDialog {
+pub fn export_frame_dialog(parent: &Window, default_name: &str) -> AsyncFileDialog {
     file_dialog_from_spec(EXPORT_FRAME_DIALOG_SPEC)
         .set_parent(parent)
-        .set_file_name("frame.png")
+        .set_file_name(default_name)
 }
 
 fn file_dialog_from_spec(spec: NativeDialogSpec) -> AsyncFileDialog {


### PR DESCRIPTION
adds export frame button to the preview toolbar. lets you save the currently viewed frame as a png or webp. defaults to naming the file with the exact timestamp. uses ffmpeg in the background to grab the raw frame cleanly. fixes #152.